### PR TITLE
fix: `EnumNotFound` not thrown when running valueOf with the name of an element in Object.prototype

### DIFF
--- a/src/ClassEnum.ts
+++ b/src/ClassEnum.ts
@@ -9,13 +9,12 @@ export default abstract class ClassEnum<T> {
 
   public static values<T>(): T[] {
     const enums = this.getEnums<T>()
-    return Object.keys(enums).map(function (name) {
-      return enums[name]
-    })
+    return Array.from(enums.values())
   }
 
-  private static getEnums<T>(): { [index: string]: T } {
-    const classEnums: { [index: string]: T } = {}
+  private static getEnums<T>(): Map<string, T> {
+    const classEnums: Map<string, T> = new Map()
+
     for (const name of Object.getOwnPropertyNames(this)) {
       if (name === 'prototype') {
         continue
@@ -27,7 +26,7 @@ export default abstract class ClassEnum<T> {
       }
 
       // @ts-ignore
-      classEnums[name] = descriptor.value
+      classEnums.set(name, descriptor.value)
     }
 
     return classEnums
@@ -35,13 +34,13 @@ export default abstract class ClassEnum<T> {
 
   public static valueOf<T>(value: string, defaultEnum: T | null = null): T {
     const enums = this.getEnums<T>()
-    if (!(value in enums)) {
+    if (!enums.has(value)) {
       if (defaultEnum !== null) {
         return defaultEnum
       }
       throw new EnumNotFound(value)
     }
-    return enums[value]
+    return enums.get(value)!
   }
 
   public name(): string {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -222,7 +222,7 @@ test.each([
   'toLocaleString',
   'toString',
   'valueOf',
-])('Cannot find enum with Object default method names', (value) => {
+])('throws EnumNotFound when value is Object prototype method name', (value) => {
   // given
   class Animal extends ClassEnum<Animal> {
     public static readonly DOG = new Animal('DOG', 'my dog')

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -214,6 +214,37 @@ test('If the enum is not found, error occurs', () => {
   expect(mouse).toThrow(EnumNotFound)
 })
 
+test.each([
+  'constructor',
+  '__proto__',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'toLocaleString',
+  'toString',
+  'valueOf',
+])('Cannot find enum with Object default method names', (value) => {
+  // given
+  class Animal extends ClassEnum<Animal> {
+    public static readonly DOG = new Animal('DOG', 'my dog')
+    public static readonly CAT = new Animal('CAT', 'my cat')
+
+    readonly title!: string
+
+    public constructor(value: string, title: string) {
+      super(value)
+      this.title = title
+    }
+  }
+
+  // when
+  const defaultMethods = () => {
+    Animal.valueOf(value)
+  }
+
+  // expected
+  expect(defaultMethods).toThrow(EnumNotFound)
+})
+
 test('Returns ETC if specified defaultValue in valueOf', () => {
   // given
   class Animal extends ClassEnum<Animal> {


### PR DESCRIPTION
# 배경
Object.prototype의 요소인, `toString`,`valueOf` 등의 이름으로 class-enum의 `valueOf`를 수행할 경우 `EnumNotFound`가 던져지지 않는 문제가 있습니다.

# 수정 사항
`getEnums` 함수의 리턴 타입을 `Map`으로 수정했습니다.